### PR TITLE
Template get

### DIFF
--- a/OptionParser.h
+++ b/OptionParser.h
@@ -61,6 +61,8 @@ class Values {
     bool is_set_by_user(const std::string& d) const { return _userSet.find(d) != _userSet.end(); }
     void is_set_by_user(const std::string& d, bool yes);
     Value get(const std::string& d) const { return (is_set(d)) ? Value((*this)[d]) : Value(); }
+    template<typename T>
+    T get(const std::string& d) const { return (is_set(d)) ? Value((*this)[d]) : T(); }
 
     typedef std::list<std::string>::iterator iterator;
     typedef std::list<std::string>::const_iterator const_iterator;

--- a/testprog.cpp
+++ b/testprog.cpp
@@ -143,6 +143,10 @@ int main(int argc, char *argv[])
   cout << "number: " << (int) options.get("number") << endl;
   cout << "int: " << (int) options.get("int") << endl;
   cout << "float: " << (float) options.get("float") << endl;
+  // test template getters
+  cout << "number<template>: " << options.get<int>("number") << endl;
+  cout << "int<template>: " << options.get<int>("int") << endl;
+  cout << "float<template>: " << options.get<float>("float") << endl;
   complex<double> c = 0;
   if (options.is_set("complex")) {
     stringstream ss;

--- a/testprog.cpp
+++ b/testprog.cpp
@@ -141,12 +141,9 @@ int main(int argc, char *argv[])
   cout << "k: " << options["k"] << endl;
   cout << "verbosity: " << options["verbosity"] << endl;
   cout << "number: " << (int) options.get("number") << endl;
-  cout << "int: " << (int) options.get("int") << endl;
+  // test template getter
+  cout << "int: " << options.get<int>("int") << endl;
   cout << "float: " << (float) options.get("float") << endl;
-  // test template getters
-  cout << "number<template>: " << options.get<int>("number") << endl;
-  cout << "int<template>: " << options.get<int>("int") << endl;
-  cout << "float<template>: " << options.get<float>("float") << endl;
   complex<double> c = 0;
   if (options.is_set("complex")) {
     stringstream ss;


### PR DESCRIPTION
Added template version of get method. Some compilers issue warnings about old style cast and C++ casts are too long to use them every time when getting option value.
